### PR TITLE
[Feat]/#41 uesrprofile database

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -13,15 +13,6 @@
         </DropdownSelection>
         <DialogSelection />
       </SelectionState>
-      <SelectionState runConfigName="NavigationMyPageActivity">
-        <option name="selectionMode" value="DROPDOWN" />
-      </SelectionState>
-      <SelectionState runConfigName="TestViewProfileButtonActivity">
-        <option name="selectionMode" value="DROPDOWN" />
-      </SelectionState>
-      <SelectionState runConfigName="TestClassAddDialogActivity">
-        <option name="selectionMode" value="DROPDOWN" />
-      </SelectionState>
     </selectionStates>
   </component>
 </project>

--- a/.idea/render.experimental.xml
+++ b/.idea/render.experimental.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RenderSettings">
+    <option name="showDecorations" value="true" />
+  </component>
+</project>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -73,6 +73,8 @@ dependencies {
     implementation("com.google.firebase:firebase-analytics")
     implementation("com.google.firebase:firebase-auth")
 
+    implementation ("com.google.firebase:firebase-firestore:24.7.0")
+    implementation ("com.google.firebase:firebase-storage:20.2.0")// 최신 버전 확인
 
     // Naver Map SDK
     implementation("com.naver.maps:map-sdk:3.19.1")

--- a/app/src/main/java/com/example/mohassu/LoginAndSignUpFragment/Signup1IDAndPWFragment.java
+++ b/app/src/main/java/com/example/mohassu/LoginAndSignUpFragment/Signup1IDAndPWFragment.java
@@ -2,6 +2,7 @@ package com.example.mohassu.LoginAndSignUpFragment;
 
 import android.os.Bundle;
 import android.text.TextUtils;
+import android.util.Patterns;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -11,31 +12,25 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.navigation.NavController;
 import androidx.navigation.Navigation;
 
 import com.example.mohassu.R;
 import com.google.firebase.auth.FirebaseAuth;
-import com.google.firebase.database.DataSnapshot;
-import com.google.firebase.database.DatabaseReference;
-import com.google.firebase.database.FirebaseDatabase;
 
 public class Signup1IDAndPWFragment extends Fragment {
 
     private FirebaseAuth auth; // Firebase Auth 인스턴스
-    private DatabaseReference databaseReference; // Firebase Database Reference
 
-    private EditText etId, etPassword, etConfirmPassword;
-    private TextView tvIdError, tvPasswordError;
-    private Button btnCheckId, btnSignupNext;
+    private EditText etEmail, etPassword, etConfirmPassword;
+    private TextView tvEmailError, tvPasswordError;
+    private Button btnCheckEmail, btnSignupNext;
 
-    private boolean isIdChecked = false; // 아이디 중복 검사 여부
+    private boolean isEmailChecked = false; // 이메일 중복 검사 여부
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-
         return inflater.inflate(R.layout.fragment_sign_up1, container, false);
     }
 
@@ -53,59 +48,73 @@ public class Signup1IDAndPWFragment extends Fragment {
 
         // Firebase 초기화
         auth = FirebaseAuth.getInstance();
-        databaseReference = FirebaseDatabase.getInstance().getReference("users"); // Firebase Database 경로
 
         // UI 요소 초기화
-        etId = view.findViewById(R.id.etId);
+        etEmail = view.findViewById(R.id.etEmail); // 이메일 입력 필드
         etPassword = view.findViewById(R.id.etPassword);
         etConfirmPassword = view.findViewById(R.id.etConfirmPassword);
-        tvIdError = view.findViewById(R.id.tvIdError);
+        tvEmailError = view.findViewById(R.id.tvEmaildError);
         tvPasswordError = view.findViewById(R.id.tvPasswordError);
-        btnCheckId = view.findViewById(R.id.btnCheckId);
+        btnCheckEmail = view.findViewById(R.id.btnCheckEmail);
         btnSignupNext = view.findViewById(R.id.btnNext);
 
-        // 아이디 중복 검사
-        btnCheckId.setOnClickListener(v -> checkIdDuplication());
+        // 이메일 중복 및 유효성 검사
+        btnCheckEmail.setOnClickListener(v -> checkEmailDuplication());
 
         // 회원가입 버튼 클릭
         btnSignupNext.setOnClickListener(v -> registerUser());
     }
 
-    private void checkIdDuplication() {
-        String userId = etId.getText().toString().trim();
+    private void checkEmailDuplication() {
+        String email = etEmail.getText().toString().trim();
+        String dummyPassword = "DummyPassword123"; // 테스트용 비밀번호 (중복 검사에만 사용)
 
-        if (TextUtils.isEmpty(userId)) {
-            tvIdError.setText("아이디를 입력해주세요.");
-            tvIdError.setVisibility(View.VISIBLE);
+        if (!isValidEmail(email)) {
+            tvEmailError.setText("유효한 이메일 주소를 입력해주세요.");
+            tvEmailError.setVisibility(View.VISIBLE);
             return;
         }
 
-        databaseReference.child(userId).get().addOnCompleteListener(task -> {
-            if (task.isSuccessful()) {
-                DataSnapshot dataSnapshot = task.getResult();
-                if (dataSnapshot.exists()) {
-                    tvIdError.setText("이미 사용 중인 아이디입니다.");
-                    tvIdError.setVisibility(View.VISIBLE);
-                    isIdChecked = false;
-                } else {
-                    tvIdError.setVisibility(View.GONE);
-                    Toast.makeText(requireContext(), "사용 가능한 아이디입니다.", Toast.LENGTH_SHORT).show();
-                    isIdChecked = true;
-                }
-            } else {
-                Toast.makeText(requireContext(), "아이디 중복 검사 실패: " + task.getException().getMessage(), Toast.LENGTH_SHORT).show();
-            }
-        });
+        // Firebase Authentication에서 중복 이메일 검사
+        auth.createUserWithEmailAndPassword(email, dummyPassword)
+                .addOnCompleteListener(task -> {
+                    if (task.isSuccessful()) {
+                        // 중복되지 않은 이메일 -> 테스트 계정 삭제
+                        auth.getCurrentUser().delete()
+                                .addOnCompleteListener(deleteTask -> {
+                                    if (deleteTask.isSuccessful()) {
+                                        tvEmailError.setVisibility(View.GONE);
+                                        Toast.makeText(requireContext(), "사용 가능한 이메일입니다.", Toast.LENGTH_SHORT).show();
+                                        isEmailChecked = true;
+                                    }
+                                });
+                    } else {
+                        // 중복된 이메일
+                        if (task.getException() != null && task.getException().getMessage().contains("email address is already in use")) {
+                            tvEmailError.setText("이미 사용 중인 이메일입니다.");
+                            tvEmailError.setVisibility(View.VISIBLE);
+                            isEmailChecked = false;
+                        } else {
+                            Toast.makeText(requireContext(), "중복 검사 실패: " + task.getException().getMessage(), Toast.LENGTH_SHORT).show();
+                        }
+                    }
+                });
     }
 
     private void registerUser() {
-        String userId = etId.getText().toString().trim();
+        String email = etEmail.getText().toString().trim();
         String password = etPassword.getText().toString().trim();
         String confirmPassword = etConfirmPassword.getText().toString().trim();
 
         // 유효성 검사
-        if (!isIdChecked) {
-            Toast.makeText(requireContext(), "아이디 중복 검사를 진행해주세요.", Toast.LENGTH_SHORT).show();
+        if (!isEmailChecked) {
+            Toast.makeText(requireContext(), "이메일 중복 검사를 진행해주세요.", Toast.LENGTH_SHORT).show();
+            return;
+        }
+
+        if (!isValidEmail(email)) {
+            tvEmailError.setText("유효한 이메일 주소를 입력해주세요.");
+            tvEmailError.setVisibility(View.VISIBLE);
             return;
         }
 
@@ -124,33 +133,21 @@ public class Signup1IDAndPWFragment extends Fragment {
         tvPasswordError.setVisibility(View.GONE);
 
         // Firebase Authentication 회원가입
-        auth.createUserWithEmailAndPassword(userId + "@gmail.com", password)
+        auth.createUserWithEmailAndPassword(email, password)
                 .addOnCompleteListener(requireActivity(), task -> {
                     if (task.isSuccessful()) {
-                        // 이메일 인증 메일 전송
-                        auth.getCurrentUser().sendEmailVerification()
-                                .addOnCompleteListener(emailTask -> {
-                                    if (emailTask.isSuccessful()) {
-                                        Toast.makeText(requireContext(), "회원가입 성공! 이메일 인증을 완료해주세요.", Toast.LENGTH_SHORT).show();
-
-                                        // Firebase Realtime Database에 사용자 데이터 저장
-                                        databaseReference.child(userId).setValue(userId)
-                                                .addOnCompleteListener(dbTask -> {
-                                                    if (dbTask.isSuccessful()) {
-                                                        // 이메일 인증 안내 화면 또는 다음 Fragment로 이동
-                                                        NavController navController = Navigation.findNavController(requireView());
-                                                        navController.navigate(R.id.actionNextToSignup2); // 적절한 Action ID로 변경
-                                                    } else {
-                                                        Toast.makeText(requireContext(), "데이터 저장 실패: " + dbTask.getException().getMessage(), Toast.LENGTH_SHORT).show();
-                                                    }
-                                                });
-                                    } else {
-                                        Toast.makeText(requireContext(), "인증 이메일 전송 실패: " + emailTask.getException().getMessage(), Toast.LENGTH_SHORT).show();
-                                    }
-                                });
+                        Toast.makeText(requireContext(), "회원가입 성공!", Toast.LENGTH_SHORT).show();
+                        // 다음 Fragment로 이동
+                        NavController navController = Navigation.findNavController(requireView());
+                        navController.navigate(R.id.actionNextToSignup2); // 적절한 Action ID로 변경
                     } else {
                         Toast.makeText(requireContext(), "회원가입 실패: " + task.getException().getMessage(), Toast.LENGTH_SHORT).show();
                     }
                 });
+    }
+
+    // 유효한 이메일 형식인지 확인
+    private boolean isValidEmail(String email) {
+        return !TextUtils.isEmpty(email) && Patterns.EMAIL_ADDRESS.matcher(email).matches();
     }
 }

--- a/app/src/main/java/com/example/mohassu/LoginAndSignUpFragment/Signup1IDAndPWFragment.java
+++ b/app/src/main/java/com/example/mohassu/LoginAndSignUpFragment/Signup1IDAndPWFragment.java
@@ -2,6 +2,7 @@ package com.example.mohassu.LoginAndSignUpFragment;
 
 import android.os.Bundle;
 import android.text.TextUtils;
+import android.util.Log;
 import android.util.Patterns;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -19,6 +20,7 @@ import androidx.navigation.Navigation;
 import com.example.mohassu.R;
 import com.google.firebase.auth.ActionCodeSettings;
 import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.auth.FirebaseUser;
 
 public class Signup1IDAndPWFragment extends Fragment {
 
@@ -26,7 +28,7 @@ public class Signup1IDAndPWFragment extends Fragment {
 
     private EditText etEmail, etPassword, etConfirmPassword;
     private TextView tvEmailError, tvPasswordError;
-    private Button btnCheckEmail, btnSignupNext;
+    private Button btnCheckEmail, btnSignupNext,btnVerifyEmail;
 
     private boolean isEmailChecked = false; // 이메일 중복 검사 여부
     private ActionCodeSettings actionCodeSettings;
@@ -57,20 +59,24 @@ public class Signup1IDAndPWFragment extends Fragment {
         etConfirmPassword = view.findViewById(R.id.etConfirmPassword);
         tvEmailError = view.findViewById(R.id.tvEmaildError);
         tvPasswordError = view.findViewById(R.id.tvPasswordError);
+
+
         btnCheckEmail = view.findViewById(R.id.btnCheckEmail);
+        btnVerifyEmail = view.findViewById(R.id.btnSendVerification);
         btnSignupNext = view.findViewById(R.id.btnNext);
 
-        // 이메일 중복 및 유효성 검사
+        // 이메일 중복 및 유효성 검사 버튼 클릭 리스너
         btnCheckEmail.setOnClickListener(v -> checkEmailDuplication());
 
-        // 회원가입 버튼 클릭
-        btnSignupNext.setOnClickListener(v -> registerUser());
+        // 회원가입 버튼 클릭 리스너
+        btnVerifyEmail.setOnClickListener(v -> registerUser());
     }
 
     private void checkEmailDuplication() {
         String email = etEmail.getText().toString().trim();
         String dummyPassword = "DummyPassword123"; // 테스트용 비밀번호 (중복 검사에만 사용)
 
+        // 이메일 형식 유효성 검사
         if (!isValidEmail(email)) {
             tvEmailError.setText("유효한 이메일 주소를 입력해주세요.");
             tvEmailError.setVisibility(View.VISIBLE);
@@ -103,29 +109,33 @@ public class Signup1IDAndPWFragment extends Fragment {
                 });
     }
 
+
     private void registerUser() {
         String email = etEmail.getText().toString().trim();
         String password = etPassword.getText().toString().trim();
         String confirmPassword = etConfirmPassword.getText().toString().trim();
 
-        // 유효성 검사
-        if (!isEmailChecked) {
-            Toast.makeText(requireContext(), "이메일 중복 검사를 진행해주세요.", Toast.LENGTH_SHORT).show();
-            return;
-        }
-
+        // 이메일 형식 검사
         if (!isValidEmail(email)) {
             tvEmailError.setText("유효한 이메일 주소를 입력해주세요.");
             tvEmailError.setVisibility(View.VISIBLE);
             return;
         }
 
+        // 이메일 중복 검사 여부 확인
+        if (!isEmailChecked) {
+            Toast.makeText(requireContext(), "이메일 중복 검사를 진행해주세요.", Toast.LENGTH_SHORT).show();
+            return;
+        }
+
+        // 비밀번호 입력 여부 확인
         if (TextUtils.isEmpty(password) || TextUtils.isEmpty(confirmPassword)) {
             tvPasswordError.setText("비밀번호를 입력해주세요.");
             tvPasswordError.setVisibility(View.VISIBLE);
             return;
         }
 
+        // 비밀번호 일치 확인
         if (!password.equals(confirmPassword)) {
             tvPasswordError.setText("비밀번호가 일치하지 않습니다.");
             tvPasswordError.setVisibility(View.VISIBLE);
@@ -143,9 +153,29 @@ public class Signup1IDAndPWFragment extends Fragment {
                                 .addOnCompleteListener(emailTask -> {
                                     if (emailTask.isSuccessful()) {
                                         Toast.makeText(requireContext(), "회원가입 성공! 인증 이메일을 확인해주세요.", Toast.LENGTH_SHORT).show();
-                                        // 다음 Fragment로 이동
-                                        NavController navController = Navigation.findNavController(requireView());
-                                        navController.navigate(R.id.actionNextToSignup2); // 적절한 Action ID로 변경
+
+//                                        // 인증 확인 버튼 활성화
+//                                        Button btnVerifyEmail = requireView().findViewById(R.id.btnVerifyEmail);
+
+                                        // 이메일 인증 확인 버튼 클릭 리스너 설정
+                                        btnSignupNext.setOnClickListener(v -> {
+                                            FirebaseUser user = FirebaseAuth.getInstance().getCurrentUser();
+                                            if (user != null) {
+                                                user.reload() // 사용자 정보 새로고침
+                                                        .addOnCompleteListener(reloadTask -> {
+                                                            if (user.isEmailVerified()) {
+                                                                Toast.makeText(requireContext(), "이메일 인증 완료!", Toast.LENGTH_SHORT).show();
+                                                                // 다음 Fragment로 이동
+                                                                NavController navController = Navigation.findNavController(requireView());
+                                                                navController.navigate(R.id.actionNextToSignup2); // 적절한 Action ID로 변경
+                                                            } else {
+                                                                Toast.makeText(requireContext(), "이메일 인증을 완료해주세요!", Toast.LENGTH_SHORT).show();
+                                                            }
+                                                        });
+                                            } else {
+                                                Toast.makeText(requireContext(), "사용자 정보를 확인할 수 없습니다.", Toast.LENGTH_SHORT).show();
+                                            }
+                                        });
                                     } else {
                                         Toast.makeText(requireContext(), "인증 이메일 발송 실패: " + emailTask.getException().getMessage(), Toast.LENGTH_SHORT).show();
                                     }
@@ -160,6 +190,4 @@ public class Signup1IDAndPWFragment extends Fragment {
     private boolean isValidEmail(String email) {
         return !TextUtils.isEmpty(email) && Patterns.EMAIL_ADDRESS.matcher(email).matches();
     }
-
-
 }

--- a/app/src/main/java/com/example/mohassu/LoginAndSignUpFragment/Signup1IDAndPWFragment.java
+++ b/app/src/main/java/com/example/mohassu/LoginAndSignUpFragment/Signup1IDAndPWFragment.java
@@ -17,6 +17,7 @@ import androidx.navigation.NavController;
 import androidx.navigation.Navigation;
 
 import com.example.mohassu.R;
+import com.google.firebase.auth.ActionCodeSettings;
 import com.google.firebase.auth.FirebaseAuth;
 
 public class Signup1IDAndPWFragment extends Fragment {
@@ -28,6 +29,7 @@ public class Signup1IDAndPWFragment extends Fragment {
     private Button btnCheckEmail, btnSignupNext;
 
     private boolean isEmailChecked = false; // 이메일 중복 검사 여부
+    private ActionCodeSettings actionCodeSettings;
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
@@ -136,10 +138,18 @@ public class Signup1IDAndPWFragment extends Fragment {
         auth.createUserWithEmailAndPassword(email, password)
                 .addOnCompleteListener(requireActivity(), task -> {
                     if (task.isSuccessful()) {
-                        Toast.makeText(requireContext(), "회원가입 성공!", Toast.LENGTH_SHORT).show();
-                        // 다음 Fragment로 이동
-                        NavController navController = Navigation.findNavController(requireView());
-                        navController.navigate(R.id.actionNextToSignup2); // 적절한 Action ID로 변경
+                        // 인증 이메일 발송
+                        auth.getCurrentUser().sendEmailVerification()
+                                .addOnCompleteListener(emailTask -> {
+                                    if (emailTask.isSuccessful()) {
+                                        Toast.makeText(requireContext(), "회원가입 성공! 인증 이메일을 확인해주세요.", Toast.LENGTH_SHORT).show();
+                                        // 다음 Fragment로 이동
+                                        NavController navController = Navigation.findNavController(requireView());
+                                        navController.navigate(R.id.actionNextToSignup2); // 적절한 Action ID로 변경
+                                    } else {
+                                        Toast.makeText(requireContext(), "인증 이메일 발송 실패: " + emailTask.getException().getMessage(), Toast.LENGTH_SHORT).show();
+                                    }
+                                });
                     } else {
                         Toast.makeText(requireContext(), "회원가입 실패: " + task.getException().getMessage(), Toast.LENGTH_SHORT).show();
                     }
@@ -150,4 +160,6 @@ public class Signup1IDAndPWFragment extends Fragment {
     private boolean isValidEmail(String email) {
         return !TextUtils.isEmpty(email) && Patterns.EMAIL_ADDRESS.matcher(email).matches();
     }
+
+
 }

--- a/app/src/main/java/com/example/mohassu/LoginAndSignUpFragment/Signup1IDAndPWFragment.java
+++ b/app/src/main/java/com/example/mohassu/LoginAndSignUpFragment/Signup1IDAndPWFragment.java
@@ -11,6 +11,7 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.navigation.NavController;
 import androidx.navigation.Navigation;
@@ -34,6 +35,7 @@ public class Signup1IDAndPWFragment extends Fragment {
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+
         return inflater.inflate(R.layout.fragment_sign_up1, container, false);
     }
 

--- a/app/src/main/java/com/example/mohassu/LoginAndSignUpFragment/Signup2DetailFragment.java
+++ b/app/src/main/java/com/example/mohassu/LoginAndSignUpFragment/Signup2DetailFragment.java
@@ -196,9 +196,11 @@ public class Signup2DetailFragment extends Fragment {
 
         // 현재 사용자 UID 가져오기
         String uid = mAuth.getCurrentUser().getUid();
+        String email = mAuth.getCurrentUser().getEmail();
 
         // Firestore에 사용자 정보 저장
         Map<String, Object> userProfile = new HashMap<>();
+        userProfile.put("email",email);
         userProfile.put("nickname", nickname);
         userProfile.put("name", name);
         userProfile.put("birthDate", birthdate);

--- a/app/src/main/java/com/example/mohassu/LoginAndSignUpFragment/Signup2DetailFragment.java
+++ b/app/src/main/java/com/example/mohassu/LoginAndSignUpFragment/Signup2DetailFragment.java
@@ -1,6 +1,131 @@
+//package com.example.mohassu.LoginAndSignUpFragment;
+//
+//import android.os.Bundle;
+//import android.view.LayoutInflater;
+//import android.view.View;
+//import android.view.ViewGroup;
+//import android.widget.Button;
+//import android.widget.DatePicker;
+//import android.widget.EditText;
+//import android.widget.Toast;
+//
+//import androidx.annotation.NonNull;
+//import androidx.fragment.app.Fragment;
+//import androidx.navigation.NavController;
+//import androidx.navigation.Navigation;
+//
+//import com.example.mohassu.R;
+//import com.google.firebase.auth.FirebaseAuth;
+//import com.google.firebase.database.DatabaseReference;
+//import com.google.firebase.database.FirebaseDatabase;
+//
+//public class Signup2DetailFragment extends Fragment {
+//
+//    private EditText etNickname, etName;
+//    private DatePicker dpBirthdate;
+//    private Button signupNextButton;
+//
+//    private FirebaseAuth mAuth;
+//    private DatabaseReference databaseReference;
+//
+////    @Override
+////    protected void onCreate(Bundle savedInstanceState) {
+////        super.onCreate(savedInstanceState);
+////        Setcon
+////
+////        //androidx.fragment.app.FragmentManager
+////        //androidx.fragment.app.FragmentTransaction
+////
+////    }
+//
+//    @Override
+//    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+//
+//        return inflater.inflate(R.layout.fragment_sign_up2, container, false);
+//    }
+//
+//    @Override
+//    public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
+//        super.onViewCreated(view, savedInstanceState);
+//
+////        getParentFragmentManager()
+////                .beginTransaction()
+////                        .replace(R.id.main,new Signup3ProfileFragment())
+////                                .commit();
+//
+//        // NavController 초기화
+//        NavController navController = Navigation.findNavController(view);
+//
+//        // 뒤로가기 버튼에 클릭 리스너 추가
+//        view.findViewById(R.id.btnBack).setOnClickListener(v -> {
+//            navController.navigateUp();
+//        });
+//
+//        // Firebase 초기화
+//        mAuth = FirebaseAuth.getInstance();
+//        databaseReference = FirebaseDatabase.getInstance().getReference("users");
+//
+//        // UI 초기화
+//        etNickname = view.findViewById(R.id.etNickname);
+//        etName = view.findViewById(R.id.etName);
+//        dpBirthdate = view.findViewById(R.id.dpSpinner);
+//        signupNextButton = view.findViewById(R.id.btnNext);
+//
+//        signupNextButton.setOnClickListener(v -> saveUserProfile(view));
+//    }
+//
+//    private void saveUserProfile(View view) {
+//        String nickname = etNickname.getText().toString().trim();
+//        String name = etName.getText().toString().trim();
+//        int day = dpBirthdate.getDayOfMonth();
+//        int month = dpBirthdate.getMonth() + 1; // Month is 0-based in DatePicker
+//        int year = dpBirthdate.getYear();
+//        String birthdate = year + "-" + month + "-" + day;
+//
+//        // 필드 유효성 검사
+//        if (nickname.isEmpty() || name.isEmpty()) {
+//            Toast.makeText(requireContext(), "모든 필드를 입력해주세요.", Toast.LENGTH_SHORT).show();
+//            return;
+//        }
+//
+//        // Firebase Realtime Database에 저장
+//        String uid = mAuth.getCurrentUser().getUid();
+//        UserProfile userProfile = new UserProfile(nickname, name, birthdate);
+//
+//        databaseReference.child(uid).setValue(userProfile)
+//                .addOnCompleteListener(task -> {
+//                    if (task.isSuccessful()) {
+//                        Toast.makeText(requireContext(), "프로필 저장 성공!", Toast.LENGTH_SHORT).show();
+//
+//                        // 다음 Fragment로 이동
+//                        NavController navController = Navigation.findNavController(requireView());
+//                        navController.navigate(R.id.actionNextToSignup3); // 적절한 Action ID로 변경
+//                    } else {
+//                        Toast.makeText(requireContext(), "프로필 저장 실패: " + task.getException().getMessage(), Toast.LENGTH_SHORT).show();
+//                    }
+//                });
+//    }
+//
+//    public static class UserProfile {
+//        public String nickname;
+//        public String name;
+//        public String birthdate;
+//
+//        public UserProfile() {
+//            // 기본 생성자
+//        }
+//
+//        public UserProfile(String nickname, String name, String birthdate) {
+//            this.nickname = nickname;
+//            this.name = name;
+//            this.birthdate = birthdate;
+//        }
+//    }
+//}
 package com.example.mohassu.LoginAndSignUpFragment;
 
 import android.os.Bundle;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -16,17 +141,21 @@ import androidx.navigation.Navigation;
 
 import com.example.mohassu.R;
 import com.google.firebase.auth.FirebaseAuth;
-import com.google.firebase.database.DatabaseReference;
-import com.google.firebase.database.FirebaseDatabase;
+import com.google.firebase.firestore.FirebaseFirestore;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class Signup2DetailFragment extends Fragment {
+
+    private static final String TAG = "Signup2DetailFragment";
 
     private EditText etNickname, etName;
     private DatePicker dpBirthdate;
     private Button signupNextButton;
 
     private FirebaseAuth mAuth;
-    private DatabaseReference databaseReference;
+    private FirebaseFirestore db;
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
@@ -37,17 +166,9 @@ public class Signup2DetailFragment extends Fragment {
     public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
-        // NavController 초기화
-        NavController navController = Navigation.findNavController(view);
-
-        // 뒤로가기 버튼에 클릭 리스너 추가
-        view.findViewById(R.id.btnBack).setOnClickListener(v -> {
-            navController.navigateUp();
-        });
-
         // Firebase 초기화
         mAuth = FirebaseAuth.getInstance();
-        databaseReference = FirebaseDatabase.getInstance().getReference("users");
+        db = FirebaseFirestore.getInstance();
 
         // UI 초기화
         etNickname = view.findViewById(R.id.etNickname);
@@ -55,6 +176,7 @@ public class Signup2DetailFragment extends Fragment {
         dpBirthdate = view.findViewById(R.id.dpSpinner);
         signupNextButton = view.findViewById(R.id.btnNext);
 
+        // 다음 버튼 클릭 리스너
         signupNextButton.setOnClickListener(v -> saveUserProfile(view));
     }
 
@@ -72,37 +194,27 @@ public class Signup2DetailFragment extends Fragment {
             return;
         }
 
-        // Firebase Realtime Database에 저장
+        // 현재 사용자 UID 가져오기
         String uid = mAuth.getCurrentUser().getUid();
-        UserProfile userProfile = new UserProfile(nickname, name, birthdate);
 
-        databaseReference.child(uid).setValue(userProfile)
-                .addOnCompleteListener(task -> {
-                    if (task.isSuccessful()) {
-                        Toast.makeText(requireContext(), "프로필 저장 성공!", Toast.LENGTH_SHORT).show();
+        // Firestore에 사용자 정보 저장
+        Map<String, Object> userProfile = new HashMap<>();
+        userProfile.put("nickname", nickname);
+        userProfile.put("name", name);
+        userProfile.put("birthDate", birthdate);
 
-                        // 다음 Fragment로 이동
-                        NavController navController = Navigation.findNavController(requireView());
-                        navController.navigate(R.id.actionNextToSignup3); // 적절한 Action ID로 변경
-                    } else {
-                        Toast.makeText(requireContext(), "프로필 저장 실패: " + task.getException().getMessage(), Toast.LENGTH_SHORT).show();
-                    }
+        db.collection("users").document(uid)
+                .set(userProfile)
+                .addOnSuccessListener(aVoid -> {
+                    Toast.makeText(requireContext(), "프로필 저장 성공!", Toast.LENGTH_SHORT).show();
+
+                    // 다음 프래그먼트로 이동
+                    NavController navController = Navigation.findNavController(view);
+                    navController.navigate(R.id.actionNextToSignup3); // 적절한 Action ID로 변경
+                })
+                .addOnFailureListener(e -> {
+                    Toast.makeText(requireContext(), "Firestore 저장 실패: " + e.getMessage(), Toast.LENGTH_SHORT).show();
+                    Log.e(TAG, "Firestore Error", e);
                 });
-    }
-
-    public static class UserProfile {
-        public String nickname;
-        public String name;
-        public String birthdate;
-
-        public UserProfile() {
-            // 기본 생성자
-        }
-
-        public UserProfile(String nickname, String name, String birthdate) {
-            this.nickname = nickname;
-            this.name = name;
-            this.birthdate = birthdate;
-        }
     }
 }

--- a/app/src/main/java/com/example/mohassu/UserProfileViewModel.java
+++ b/app/src/main/java/com/example/mohassu/UserProfileViewModel.java
@@ -1,0 +1,47 @@
+package com.example.mohassu;
+
+import android.net.Uri;
+
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MutableLiveData;
+import androidx.lifecycle.ViewModel;
+
+public class UserProfileViewModel extends ViewModel {
+    private final MutableLiveData<String> nickname = new MutableLiveData<>();
+    private final MutableLiveData<String> name = new MutableLiveData<>();
+    private final MutableLiveData<String> birthDate = new MutableLiveData<>();
+    private final MutableLiveData<Uri> photoUri = new MutableLiveData<>();
+
+    public void setNickname(String nickname) {
+        this.nickname.setValue(nickname);
+    }
+
+    public LiveData<String> getNickname() {
+        return nickname;
+    }
+
+    public void setName(String name) {
+        this.name.setValue(name);
+    }
+
+    public LiveData<String> getName() {
+        return name;
+    }
+
+    public void setBirthDate(String birthDate) {
+        this.birthDate.setValue(birthDate);
+    }
+
+    public LiveData<String> getBirthDate() {
+        return birthDate;
+    }
+
+    public void setPhotoUri(Uri uri) {
+        this.photoUri.setValue(uri);
+    }
+
+    public LiveData<Uri> getPhotoUri() {
+        return photoUri;
+    }
+
+}

--- a/app/src/main/res/layout/fragment_sign_up1.xml
+++ b/app/src/main/res/layout/fragment_sign_up1.xml
@@ -1,79 +1,77 @@
-<?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
     android:background="@android:color/white"
+    android:orientation="vertical"
     android:padding="16dp">
 
     <!-- 상단 Back 버튼과 제목 -->
     <FrameLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        android:gravity="center_vertical">
+        android:gravity="center_vertical"
+        android:orientation="horizontal">
 
         <ImageButton
             android:id="@+id/btnBack"
             android:layout_width="48dp"
             android:layout_height="48dp"
-            android:src="@drawable/ic_back"
-            android:contentDescription="뒤로가기 버튼"
             android:background="?selectableItemBackground"
-            android:foregroundTint="@color/black" />
+            android:contentDescription="뒤로가기 버튼"
+            android:foregroundTint="@color/black"
+            android:src="@drawable/ic_back" />
 
         <TextView
             android:id="@+id/tvTitle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center"
-            android:text="모하SSU 회원가입"
-            android:textStyle="bold"
-            android:textSize="20sp"
             android:layout_marginStart="8dp"
-            android:textColor="@color/black" />
+            android:text="모하SSU 회원가입"
+            android:textColor="@color/black"
+            android:textSize="20sp"
+            android:textStyle="bold" />
     </FrameLayout>
 
     <View
         android:layout_width="match_parent"
         android:layout_height="1dp"
-        android:background="#BDBDBD"
-        android:layout_marginBottom="40dp" />
+        android:layout_marginBottom="40dp"
+        android:background="#BDBDBD" />
 
     <!-- 화면 간격 -->
     <TextView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="아이디와 비밀번호를 입력해주세요!"
-        android:textStyle="bold"
-        android:textSize="24sp"
-        android:gravity="center"
         android:layout_marginTop="24dp"
         android:layout_marginBottom="36dp"
-        android:textColor="@color/black" />
+        android:gravity="center"
+        android:text="아이디와 비밀번호를 입력해주세요!"
+        android:textColor="@color/black"
+        android:textSize="24sp"
+        android:textStyle="bold" />
 
     <!-- 아이디 입력 영역 -->
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="아이디"
-        android:textSize="16sp"
-        android:textColor="@color/black"
+        android:layout_marginTop="16dp"
         android:layout_marginBottom="8dp"
-        android:layout_marginTop="16dp" />
+        android:text="아이디"
+        android:textColor="@color/black"
+        android:textSize="16sp" />
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        android:gravity="center_vertical">
+        android:gravity="center_vertical"
+        android:orientation="horizontal">
 
         <EditText
             android:id="@+id/etEmail"
             android:layout_width="0dp"
-            android:layout_weight="1"
             android:layout_height="wrap_content"
+            android:layout_weight="1"
             android:hint="이메일을 입력해주세요"
             android:inputType="text"
             android:padding="12dp"
@@ -81,43 +79,33 @@
 
         <Button
             android:id="@+id/btnCheckEmail"
+            style="@style/BlueMaterialButtonStyle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="중복 검사"
             android:layout_marginStart="8dp"
-            style="@style/BlueMaterialButtonStyle"
+            android:text="중복 검사"
             android:textColor="@android:color/white" />
     </LinearLayout>
-
-<!--    <TextView-->
-<!--        android:id="@+id/tvIdError"-->
-<!--        android:layout_width="match_parent"-->
-<!--        android:layout_height="wrap_content"-->
-<!--        android:text="*아이디 중복검사를 먼저 해주세요"-->
-<!--        android:textSize="14sp"-->
-<!--        android:textColor="@color/red"-->
-<!--        android:layout_marginTop="4dp"-->
-<!--        android:visibility="gone" />-->
 
     <TextView
         android:id="@+id/tvEmaildError"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="*이메일을 입력해주세요"
-        android:textSize="14sp"
-        android:textColor="@color/red"
         android:layout_marginTop="4dp"
+        android:text="*이메일을 입력해주세요"
+        android:textColor="@color/red"
+        android:textSize="14sp"
         android:visibility="gone" />
 
     <!-- 비밀번호 입력 영역 -->
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="비밀번호"
-        android:textSize="16sp"
-        android:textColor="@color/black"
+        android:layout_marginTop="16dp"
         android:layout_marginBottom="8dp"
-        android:layout_marginTop="16dp" />
+        android:text="비밀번호"
+        android:textColor="@color/black"
+        android:textSize="16sp" />
 
     <EditText
         android:id="@+id/etPassword"
@@ -132,11 +120,11 @@
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="비밀번호 재확인"
-        android:textSize="16sp"
-        android:textColor="@color/black"
+        android:layout_marginTop="16dp"
         android:layout_marginBottom="8dp"
-        android:layout_marginTop="16dp" />
+        android:text="비밀번호 재확인"
+        android:textColor="@color/black"
+        android:textSize="16sp" />
 
     <EditText
         android:id="@+id/etConfirmPassword"
@@ -151,23 +139,43 @@
         android:id="@+id/tvPasswordError"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="*비밀번호가 일치하지 않습니다"
-        android:textSize="14sp"
-        android:textColor="@color/red"
         android:layout_marginTop="4dp"
+        android:text="*비밀번호가 일치하지 않습니다"
+        android:textColor="@color/red"
+        android:textSize="14sp"
         android:visibility="gone" />
 
-    <!-- 다음 버튼 -->
-    <Button
-        android:id="@+id/btnNext"
-        android:layout_width="wrap_content"
+    <!-- 버튼 영역 -->
+    <LinearLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        android:text="다음"
-        android:textSize="16sp"
-        android:textStyle="bold"
-        android:layout_marginTop="160dp"
-        style="@style/BlueMaterialButtonStyle"
-        android:textColor="@android:color/white" />
+        android:layout_marginTop="40dp"
+        android:gravity="center"
+        android:orientation="horizontal">
+
+        <Button
+            android:id="@+id/btnSendVerification"
+            style="@style/BlueMaterialButtonStyle"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:layout_marginEnd="8dp"
+            android:text="인증 메일 발송"
+            android:textColor="@android:color/white"
+            android:textSize="16sp"
+            android:textStyle="bold" />
+
+        <Button
+            android:id="@+id/btnNext"
+            style="@style/BlueMaterialButtonStyle"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:layout_marginStart="8dp"
+            android:text="다음"
+            android:textColor="@android:color/white"
+            android:textSize="16sp"
+            android:textStyle="bold" />
+    </LinearLayout>
 
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_sign_up1.xml
+++ b/app/src/main/res/layout/fragment_sign_up1.xml
@@ -70,17 +70,17 @@
         android:gravity="center_vertical">
 
         <EditText
-            android:id="@+id/etId"
+            android:id="@+id/etEmail"
             android:layout_width="0dp"
             android:layout_weight="1"
             android:layout_height="wrap_content"
-            android:hint="아이디를 입력해주세요"
+            android:hint="이메일을 입력해주세요"
             android:inputType="text"
             android:padding="12dp"
             android:textColor="@color/black" />
 
         <Button
-            android:id="@+id/btnCheckId"
+            android:id="@+id/btnCheckEmail"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="중복 검사"
@@ -89,11 +89,21 @@
             android:textColor="@android:color/white" />
     </LinearLayout>
 
+<!--    <TextView-->
+<!--        android:id="@+id/tvIdError"-->
+<!--        android:layout_width="match_parent"-->
+<!--        android:layout_height="wrap_content"-->
+<!--        android:text="*아이디 중복검사를 먼저 해주세요"-->
+<!--        android:textSize="14sp"-->
+<!--        android:textColor="@color/red"-->
+<!--        android:layout_marginTop="4dp"-->
+<!--        android:visibility="gone" />-->
+
     <TextView
-        android:id="@+id/tvIdError"
+        android:id="@+id/tvEmaildError"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="*아이디 중복검사를 먼저 해주세요"
+        android:text="*이메일을 입력해주세요"
         android:textSize="14sp"
         android:textColor="@color/red"
         android:layout_marginTop="4dp"


### PR DESCRIPTION

Signup1 
- Firestore 저장 정보 변경
- 아이디 중복 검사 변경 (기존) RealTime -> (변경) 입력받은 아이디(이메일)을 통해 FirebaseAuth을 통해 검증
- 인증 메일 발송과 다음 버튼 분리 ( 유효성 검사도 분리 )
![스크린샷 2024-12-04 오후 5 29 37](https://github.com/user-attachments/assets/b13a47b8-2e3e-43f5-afb4-e84d6bc15f2c)

DataBase 구조 

users (Collection)
  └── userId123 (Document)
        ├── name: "Jane Doe"
        ├── nickName: "Jane Doe"
        ├── email: "jane@example.com"
        ├── photoUrl: "https://example.com/photo.jpg"
        ├── birthDate: "1990-01-01"
        ├── photoUrl :~~~
        
        추후 시간표 Collection 추가예정 / 친구 리스트 약속 리스트 등등